### PR TITLE
GameInfoのTalk_listがdayごとに管理されることに伴って、GameLogが重複して記録されてしまう・InfluenceConsiderationModuleで一度返答した問題に再度返答してしまう問題の修正

### DIFF
--- a/aiwolfk2b/AttentionReasoningAgent/Modules/InfluenceConsiderationModule.py
+++ b/aiwolfk2b/AttentionReasoningAgent/Modules/InfluenceConsiderationModule.py
@@ -1,5 +1,6 @@
 import re
 from configparser import ConfigParser
+from collections import defaultdict
 from typing import List,Tuple,Dict,Any,Union
 from enum import Enum
 
@@ -10,7 +11,6 @@ from aiwolfk2b.AttentionReasoningAgent.AbstractModules import AbstractInfluenceC
 from aiwolfk2b.AttentionReasoningAgent.AbstractModules.AbstractStrategyModule import ActionType
 from aiwolfk2b.utils.helper import calc_closest_str,load_default_config,load_default_GameInfo,load_default_GameSetting
 from aiwolfk2b.AttentionReasoningAgent.Modules.GPTProxy import GPTAPI,ChatGPTAPI
-
 
 class InfluenceType(Enum):
     NO_CALL = 0
@@ -23,11 +23,24 @@ class InfluenceConsiderationModule(AbstractInfluenceConsiderationModule):
     """他者から自分への投げかけがあるかをChatGPT(or GPT3)を使って判定して、他者質問・他者要求処理モジュールを使って返答を行うモジュール"""
     def __init__(self, config: ConfigParser,request_processing_module:AbstractRequestProcessingModule, question_processing_module:AbstractQuestionProcessingModule) -> None:
         super().__init__(config,request_processing_module,question_processing_module)
-        self.chatgpt = ChatGPTAPI()
-        self.gpt = GPTAPI()
+        #gptまわりの設定 
+        self.chatgpt_model= self.config.get("InfluenceConsiderationModule","chatgpt_model")
+        self.chatgpt_max_tokens = self.config.getint("InfluenceConsiderationModule","chatgpt_max_tokens")
+        self.chatgpt_temperature = self.config.getfloat("InfluenceConsiderationModule","chatgpt_temperature")
+        self.gpt_model= self.config.get("InfluenceConsiderationModule","gpt_model")
+        self.gpt_max_tokens = self.config.getint("InfluenceConsiderationModule","gpt_max_tokens")
+        self.gpt_temperature = self.config.getfloat("InfluenceConsiderationModule","gpt_temperature")
+        #openAIのAPIを読み込む
+        self.chatgpt = ChatGPTAPI(self.chatgpt_model,self.chatgpt_max_tokens,self.chatgpt_temperature)
+        self.gpt = GPTAPI(self.gpt_model,self.gpt_max_tokens,self.gpt_temperature)
     
     def initialize(self, game_info: GameInfo, game_setting: GameSetting) -> None:
         super().initialize(game_info, game_setting)
+        #一度分類した投げかけを再利用するための辞書
+        #一度返答した内容を繰り返し返答することは避ける
+        self.considered_talk_dict:Dict[Tuple[int,int],InfluenceType] = defaultdict(lambda:None)
+
+
         
     def check_influence(self, game_info: GameInfo, game_setting: GameSetting) -> Tuple[bool,OneStepPlan]:
         """
@@ -53,6 +66,15 @@ class InfluenceConsiderationModule(AbstractInfluenceConsiderationModule):
             if talk.agent == game_info.me:
                 continue
             
+            #OverやSkipは無視
+            if talk.text == "Over" or talk.text == "Skip":
+                continue
+            
+            #一度返答した投げかけは無視
+            if self.considered_talk_dict[(talk.day,talk.idx)] is not None:
+                print("already considered talk")
+                continue
+            
             #正規表現を使って>> Agent[自分のid]があるかを判定
             positively_mentioned = re.match(r'\s*>>\s*' + re.escape(str(game_info.me)), talk.text)
             positively_mentioned = True if positively_mentioned is not None else False
@@ -63,6 +85,11 @@ class InfluenceConsiderationModule(AbstractInfluenceConsiderationModule):
             
             #自分に対する要求,質問,その他の投げかけ,or 投げかけではないかをGPTによって判定
             influence_type = self.classify_question_or_request(text_removed,game_info,game_setting,positively_mentioned)
+            
+            #投げかけを処理したことを保存
+            self.considered_talk_dict[(talk.day,talk.idx)] = influence_type
+            
+            
             if influence_type == InfluenceType.NO_CALL and not positively_mentioned:
                 # 陽に自分への投げかけがなく、かつGPTが自分への投げかけと判定しなかった場合は、自分への投げかけがないと判定
                 # print(f"{game_info.me}への投げかけではない:{talk.text}")
@@ -135,7 +162,6 @@ class InfluenceConsiderationModule(AbstractInfluenceConsiderationModule):
             "みんな頑張ろう！":3,
             "俺に投票しないでほしい":2,
             "Agentは人狼だと思います":0,
-            "みんな元気？":3,
             "頑張りたいと思います":0,
             "占い師です。占った結果Agentが人狼でした":0,
             "お前ら頑張るぞ":3,

--- a/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
+++ b/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
@@ -57,15 +57,15 @@ class GameLog:
         self._talk_list_updated = True
         self.truncate_words = truncate_words
         #一度記録したTalkの内容は保存しておく
-        self.saved_text_idx:Set[Tuple[int,int]] = set()
+        self.saved_text_idx_set:Set[Tuple[int,int]] = set()
     
     def update(self, game_info:GameInfo, game_setting:GameSetting)->None:
         #更新されるものがあるときだけ更新
         for talk in game_info.talk_list:
             talk_day,talk_idx = talk.day,talk.idx
-            if  (talk_day,talk_idx)  in self.saved_text_idx:
+            if  (talk_day,talk_idx)  in self.saved_text_idx_set:
                 self._talk_list.append(talk)
-                self.saved_text_idx.add((talk_day,talk_idx))
+                self.saved_text_idx_set.add((talk_day,talk_idx))
                 self._talk_list_updated = True
             else:
                 print("already saved")

--- a/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
+++ b/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
@@ -63,7 +63,8 @@ class GameLog:
         #更新されるものがあるときだけ更新
         for talk in game_info.talk_list:
             talk_day,talk_idx = talk.day,talk.idx
-            if  (talk_day,talk_idx)  in self.saved_text_idx_set:
+            if  (talk_day,talk_idx) not in self.saved_text_idx_set:
+                #print("new talk")
                 self._talk_list.append(talk)
                 self.saved_text_idx_set.add((talk_day,talk_idx))
                 self._talk_list_updated = True
@@ -590,14 +591,24 @@ if __name__=="__main__":
     game_info = load_default_GameInfo()
     game_setting = load_default_GameSetting()
     
-    role_estimation_model = RandomRoleEstimationModel(config_ini)
-    role_inference_module = SimpleRoleInferenceModule(config_ini, role_estimation_model)
+    # role_estimation_model = RandomRoleEstimationModel(config_ini)
+    # role_inference_module = SimpleRoleInferenceModule(config_ini, role_estimation_model)
     
-    strategy_module = StrategyModule(config_ini, role_estimation_model, role_inference_module)
-    strategy_module.initialize(game_info, game_setting)
+    # strategy_module = StrategyModule(config_ini, role_estimation_model, role_inference_module)
+    # strategy_module.initialize(game_info, game_setting)
     game_info.status_map= {Agent(1):Status.ALIVE, Agent(2):Status.ALIVE, Agent(3):Status.ALIVE, Agent(4):Status.ALIVE, Agent(5):Status.ALIVE}
     game_info.talk_list = [Talk(day=1,agent=game_info.agent_list[0], idx=1, text="占い師COします。占い結果はAgent[02]が白でした。", turn=1),Talk(day=1,agent=game_info.agent_list[1], idx=2, text="1占いCO把握", turn=1),Talk(day=1,agent=game_info.agent_list[2], idx=3, text="占い師COします。Agent[01]を占って黒でした。", turn=1) , Talk(day=1,agent=game_info.agent_list[3], idx=4, text="村人です", turn=1), Talk(day=1,agent=game_info.agent_list[4], idx=5, text="村人です。", turn=1)]
     game_info.day = 1
-    print(strategy_module.talk(game_info, game_setting))
-    print(strategy_module.talk(game_info, game_setting))
-    print(strategy_module.comingout_status.all_comingout_status)
+    # print(strategy_module.talk(game_info, game_setting))
+    # print(strategy_module.talk(game_info, game_setting))
+    # print(strategy_module.comingout_status.all_comingout_status)
+    
+    # GameLogクラスの単体テスト
+    ## 重複した発言が追加されないことを確認する
+    game_logger = GameLog(game_info,game_setting)
+    print("update_0:何も出力されない",game_logger.log,sep="\n")
+    game_logger.update(game_info, game_setting) #ここで追加
+    print("update_1:会話ログが出力される",game_logger.log,sep="\n")
+    game_logger.update(game_info, game_setting) #ここで追加されない
+    print("update_2:update_1と同じ会話ログが出力される(重複して保存されない)",game_logger.log,sep="\n")
+    

--- a/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
+++ b/aiwolfk2b/AttentionReasoningAgent/Modules/StrategyModule.py
@@ -1,6 +1,6 @@
 import os,random,re
 from configparser import ConfigParser
-from typing import List,Tuple,Dict,Any,Union, Optional
+from typing import List,Tuple,Dict,Any,Union, Optional,Set
 from enum import Enum
 import numpy as np
 
@@ -11,7 +11,7 @@ from aiwolf.agent import Agent,Role, Species
 from aiwolfk2b.AttentionReasoningAgent.AbstractModules import AbstractRoleEstimationModel,RoleEstimationResult,AbstractStrategyModule,AbstractRoleInferenceModule,RoleInferenceResult,OneStepPlan, ActionType
 from aiwolfk2b.AttentionReasoningAgent.Modules.GPTProxy import GPTAPI,ChatGPTAPI
 from aiwolfk2b.utils.helper import load_default_config,load_default_GameInfo,load_default_GameSetting,calc_closest_str,make_gpt_qa_prompt
-
+from collections import defaultdict
 class GameLog:
     """ゲームのログを保存するクラス"""
     
@@ -38,7 +38,7 @@ class GameLog:
         else:
             return self._log #ログが短いときはそのまま返す
     
-    def __init__(self, game_info:GameInfo, game_setting:GameSetting,truncate_words = 2000) -> None:
+    def __init__(self, game_info:GameInfo, game_setting:GameSetting,truncate_words = 3000) -> None:
         """
         コンストラクタ
 
@@ -56,10 +56,19 @@ class GameLog:
         self._log_talk_numbers = 0
         self._talk_list_updated = True
         self.truncate_words = truncate_words
+        #一度記録したTalkの内容は保存しておく
+        self.saved_text_idx:Set[Tuple[int,int]] = set()
     
     def update(self, game_info:GameInfo, game_setting:GameSetting)->None:
-        self._talk_list.extend(game_info.talk_list)
-        self._talk_list_updated = True
+        #更新されるものがあるときだけ更新
+        for talk in game_info.talk_list:
+            talk_day,talk_idx = talk.day,talk.idx
+            if  (talk_day,talk_idx)  in self.saved_text_idx:
+                self._talk_list.append(talk)
+                self.saved_text_idx.add((talk_day,talk_idx))
+                self._talk_list_updated = True
+            else:
+                print("already saved")
 
 
 class TalkTopic(Enum):
@@ -78,27 +87,36 @@ class ComingOutStatus:
         for agent in game_info.agent_list:
             self.all_comingout_status[agent] = Role.UNC
             self.gpt3_api =GPTAPI()
+            #一度処理したTalkの内容は保存しておく
+            self.processed_text_idx:Set[Tuple[int,int]] = set()
 
     def update(self, game_info:GameInfo, game_setting:GameSetting)->None:
+        explanation = "以下の発言に対し、カミングアウト(役職の公開)かどうかとその役職を判定してください。カミングアウトが無ければ無しとこたえてください。役職は、人狼・狂人・占い師・村人の4種類で答えてください。"
+        examples = {
+            "占いCOします。Agentは白でした。": "占い師",
+            "占い師だ。Agentは人狼だった": "占い師",
+            "占い師をやってみるかな、ってことでCOするぜ。": "占い師",
+            "ガオー、人狼だぞー": "人狼",
+            "人狼として頑張るぞ": "人狼",
+            "俺は村人です。仲良くやりましょう！": "村人",
+            "僕は村人、よろしく": "村人",
+            "あら、村人なのね。一緒に頑張りましょうわ、ね？": "村人",
+            "わたし、村っ子だよ！がんばるぞー！": "村人",
+            "わたしは狂人です。人狼をサポートします。": "狂人",
+            "みなさんよろしくお願いします": "無し",
+            "よろー": "無し",
+            "お元気ですか？": "無し",
+            "こんにちは": "無し",
+        }
         if not self.is_all_comingout():
             for talk in game_info.talk_list:
-                explanation = "以下の発言に対し、カミングアウト(役職の公開)かどうかとその役職を判定してください。カミングアウトが無ければ無しとこたえてください。役職は、人狼・狂人・占い師・村人の4種類で答えてください。"
-                examples = {
-                    "占いCOします。Agentは白でした。": "占い師",
-                    "占い師だ。Agentは人狼だった": "占い師",
-                    "占い師をやってみるかな、ってことでCOするぜ。": "占い師",
-                    "ガオー、人狼だぞー": "人狼",
-                    "人狼として頑張るぞ": "人狼",
-                    "俺は村人です。仲良くやりましょう！": "村人",
-                    "僕は村人、よろしく": "村人",
-                    "あら、村人なのね。一緒に頑張りましょうわ、ね？": "村人",
-                    "わたし、村っ子だよ！がんばるぞー！": "村人",
-                    "わたしは狂人です。人狼をサポートします。": "狂人",
-                    "みなさんよろしくお願いします": "無し",
-                    "よろー": "無し",
-                    "お元気ですか？": "無し",
-                    "こんにちは": "無し",
-                }
+                talk_day,talk_idx = talk.day,talk.idx
+                #一度処理したTalkはスキップ
+                if (talk_day,talk_idx)  in self.processed_text_idx:
+                    continue
+                #一度処理したTalkの内容は保存しておく
+                self.processed_text_idx.add((talk_day,talk_idx))
+                
                 #テキストの前処理として、自分以外のAgent[数字]をAgentに置き換えたうえで質問とする
                 question = re.sub(r"Agent\[(\d+)\]",lambda m: f"Agent" if int(m.group(1)) != game_info.me.agent_idx else f"{game_info.me}" ,talk.text)
                 prompt = self.gpt3_api.make_gpt_qa_prompt(explanation, examples,question)
@@ -124,6 +142,17 @@ class ComingOutStatus:
             if role == Role.UNC:
                 return False
         return True
+    
+    def has_seer(self)->Tuple[bool,List[Agent]]:
+        seers = []
+        for agent, role in self.all_comingout_status.items():
+            if role == Role.SEER:
+                seers.append(agent)
+        
+        if len(seers) == 0:
+            return False, []
+        else:
+            return True, seers
 
 class StrategyModule(AbstractStrategyModule):
     """戦略立案モジュール"""
@@ -480,21 +509,28 @@ class StrategyModule(AbstractStrategyModule):
         
     def talk_roleaction_reaction(self, game_info:GameInfo, game_setting:GameSetting)->Optional[str]:
         """COや占い結果に反応したり、占い理由を聞いたりする。"""
-        if not self.comingout_status.is_all_comingout:
-            return "占い師の人がいたらCOしてください"
+        if not self.comingout_status.is_all_comingout():
+            has_seer,agents = self.comingout_status.has_seer()
+            if has_seer:
+                text = f"{agents[0]}さん"
+                for a in agents[1:]:
+                    text += f"、{a}さん"
+                return text + "が占い師だそうですが、他にも占い師がいたらCOしてください"
+            else:
+                return "占い師の人がいたらCOしてください"
         self.today_talked_topic[TalkTopic.ROLEACTION_REACTION] = True
         if self.today == 1:
             # 1日目はCOの状況に反応する(状況を整理する)
             # GPT4にやらせる
             messages = [{"role": "system", "content":f"あなたは今人狼ゲームをしています。あなたは{game_info.me}です。対戦ログと指示が送られてきますので、対戦ログの結果と発言するべきことが送られてきますので、適切に返答してください。"}, 
-                        {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。誰が占い師カミングアウトしているかなどの状況を整理して会話を発展させてください。誰かに向けて発言するときは、「>>Agent[01] 」などと文頭につけてください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
+                        {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。誰が占い師カミングアウトしているかなどの状況を整理して会話を発展させてください。Agent[01]に向けて発言するときは、「>>Agent[01] 」、Agent[02]に向けて発言するときは、「>>Agent[02] 」、Agent[03]に向けて発言するときは、「>>Agent[03] 」、Agent[04]に向けて発言するときは、「>>Agent[04] 」、Agent[03]に向けて発言するときは、「>>Agent[05] 」と文頭につけてください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
             response = self.chatgpt_api.complete(messages)
             return response
         else:
             # 2日目は占い理由を聞く
             # GPT4にやらせる
             messages = [{"role": "system", "content":"あなたは今人狼ゲームをしています。あなたは{game_info.me}です。対戦ログと指示が送られてきますので、対戦ログの結果と発言するべきことが送られてきますので、適切に返答してください。"}, 
-                        {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。占い師COした人に、なぜその人を占ったか聞くなどしてください。誰かに向けて発言するときは、「>>Agent[01] 」などと文頭につけてください。ただし他の人が既に聞いてた場合は、もう言う必要は無いので、SKIPと発言してください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
+                        {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。占い師COした人に、なぜその人を占ったか聞くなどしてください。Agent[01]に向けて発言するときは、「>>Agent[01] 」、Agent[02]に向けて発言するときは、「>>Agent[02] 」、Agent[03]に向けて発言するときは、「>>Agent[03] 」、Agent[04]に向けて発言するときは、「>>Agent[04] 」、Agent[03]に向けて発言するときは、「>>Agent[05] 」と文頭につけてください。ただし他の人が既に聞いてた場合は、もう言う必要は無いので、SKIPと発言してください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
             response = self.chatgpt_api.complete(messages)
             return response
 
@@ -528,14 +564,16 @@ class StrategyModule(AbstractStrategyModule):
     
     def talk_no_topic(self, game_info:GameInfo, game_setting:GameSetting)->Optional[str]:
         """話題がないときに話す"""
-        # #GPT4にやらせる
-        # messages = [{"role": "system", "content":f"あなたは今人狼ゲームをしています。あなたは{game_info.me}です。対戦ログと指示が送られてきますので、対戦ログの結果と発言するべきことが送られてきますので、適切に返答してください。"}, 
-        #                 {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。まだ何か人狼ゲーム上重要なことで言うべきことがあれば言ってください(弁明、他者への質問など)。言うことが無ければ「Over」と返してください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
-        # response = self.chatgpt_api.complete(messages)
-        # return response
+        #GPT4にやらせる
+        messages = [{"role": "system", "content":f"あなたは今人狼ゲームをしています。あなたは{game_info.me}です。対戦ログと指示が送られてきますので、対戦ログの結果と発言するべきことが送られてきますので、適切に返答してください。"}, 
+                        {"role": "user", "content":f"今の人狼ゲームのログは以下です。\n===========\n{self.game_log.log}\n==========\nここで、あなた({game_info.me})の発言のターンです。まだ何か人狼ゲーム上重要なことで言うべきことがあれば言ってください(弁明、他者への質問など)。言うことが無ければ「Over」と返してください。\n{game_info.day}日目 {game_info.me}の発言 :"}]
+        response = self.chatgpt_api.complete(messages)
+        return response
         
-        #トークン数の関係で、常にOverを返すようにする
-        return "Over"
+        # #トークン数の関係で、常にOverを返すようにする
+        # return "Over"
+        # #トークン数の関係で、常にSkipを返すようにする
+        # return "Skip"
     
     def add_vote_future_plan(self, one_step_plan:OneStepPlan)->None:
         for plan in self.future_plan:

--- a/aiwolfk2b/AttentionReasoningAgent/config.ini
+++ b/aiwolfk2b/AttentionReasoningAgent/config.ini
@@ -34,9 +34,12 @@ gpt_max_tokens = 256
 gpt_temperature = 1.0
 
 [InfluenceConsiderationModule]
-gpt_model=gpt-3.5-turbo-0613
+gpt_model=text-davinci-003
 gpt_max_tokens = 256
 gpt_temperature = 0
+chatgpt_model=gpt-3.5-turbo-0613
+chatgpt_max_tokens = 256
+chatgpt_temperature = 1.0
 
 [SpeakerModule]
 character1=中年の大雑把なおじさん風(1人称は俺、標準語で話す)

--- a/aiwolfk2b/AttentionReasoningAgent/test_influence.py
+++ b/aiwolfk2b/AttentionReasoningAgent/test_influence.py
@@ -111,6 +111,10 @@ if __name__ == '__main__':
     talk_list = [Talk(agent=Agent(4),text=">>Agent[02] Agent[01]を占ったのはなぜなんじゃ？おしえてくれませんかのう",turn=1,idx=1)]
     test_influence_module(influence_module,talk_list,me)
     
-        
+    ### 一度返答したら、再度同じ内容を返答しないかのテスト
+    talk_list = [Talk(agent=Agent(4),text=">> Agent[01] Agent[03]を占ってほしい",turn=1,idx=1)]
+    test_influence_module(influence_module,talk_list,me)
+    talk_list = [Talk(agent=Agent(4),text=">> Agent[01] Agent[03]を占ってほしい",turn=1,idx=1)]
+    test_influence_module(influence_module,talk_list,me)
         
         


### PR DESCRIPTION
## 変更の概要
+ InfluenceConsiderationModuleで一度返答した問題に再度返答する問題があったので修正
    - 一度返答したら、再度同じ内容を返答しないかのテストをtest_influence.pyで検証済み
+ StrategyModule.pyのGameLogクラスで同じひとの会話を重複して記録する問題を修正
    - test_gamelog()にて同じ内容を重複して記録しないかの検証済み
+ StrategyModule.pyのCommingOutStatusクラスにて、一度判定した文を再度判定する可能性がある問題に対処
    - 現状の処理の都合で、一周目(day1のturn1)が終わると絶対にis_all_commingoutがTrueになるため、繰り返し呼ばれることは殆ど無いが念の為。

## 課題
+ 特になし。

##  プログラムの実行方法
[README](https://github.com/kzk-program/AIWolfK2B/blob/feature/improve/RoleEstimationModel/README.md)に記載の通り。

## 備考
+ 単体テストをして問題がないか確認してほしい
+ プログラムに問題（バグ・書きかたの改善点）がないかも確認してほしい